### PR TITLE
avoid merging request and response event properties

### DIFF
--- a/src/main/java/org/mule/modules/cors/CORSModule.java
+++ b/src/main/java/org/mule/modules/cors/CORSModule.java
@@ -16,25 +16,28 @@
 
 package org.mule.modules.cors;
 
-import org.apache.commons.lang.StringUtils;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
+import org.mule.api.MuleMessage;
+import org.mule.api.annotations.Configurable;
+import org.mule.api.annotations.Module;
+import org.mule.api.annotations.Processor;
 import org.mule.api.annotations.lifecycle.Start;
 import org.mule.api.annotations.lifecycle.Stop;
 import org.mule.api.annotations.param.Default;
 import org.mule.api.annotations.param.Optional;
-import org.mule.api.context.MuleContextAware;
+import org.mule.api.callback.SourceCallback;
 import org.mule.api.store.ObjectStore;
 import org.mule.api.store.ObjectStoreException;
 import org.mule.api.store.ObjectStoreManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.mule.api.MuleMessage;
-import org.mule.api.annotations.*;
-import org.mule.api.callback.SourceCallback;
+
+import java.util.List;
 
 import javax.inject.Inject;
-import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cloud Connector
@@ -143,7 +146,7 @@ public class CORSModule
      */
     @Processor(intercepting = true)
     @Inject
-    public MuleMessage validate(SourceCallback callback, MuleEvent event, @Optional @Default("false")
+    public MuleEvent validate(SourceCallback callback, MuleEvent event, @Optional @Default("false")
         boolean publicResource, @Optional @Default("false") boolean acceptsCredentials) throws Exception {
 
         if (publicResource && acceptsCredentials) {
@@ -160,7 +163,7 @@ public class CORSModule
         if (StringUtils.isEmpty(origin)) {
 
             if (logger.isDebugEnabled()) logger.debug("Request is not a CORS request.");
-            return callback.processEvent(event).getMessage();
+            return callback.processEvent(event);
         }
 
         //read headers including those of the preflight
@@ -183,7 +186,7 @@ public class CORSModule
         //finally configure the CORS headers
         configureCorsHeaders(event.getMessage(), method, origin, requestMethod, requestHeaders, publicResource, acceptsCredentials);
 
-        return result.getMessage();
+        return result;
     }
 
     private void configureCorsHeaders(MuleMessage message, String method, String origin, String requestMethod,

--- a/src/test/java/com/mulesoft/modules/cors/CORSModuleTest.java
+++ b/src/test/java/com/mulesoft/modules/cors/CORSModuleTest.java
@@ -16,18 +16,25 @@
 
 package com.mulesoft.modules.cors;
 
-import java.util.HashMap;
-import org.junit.Test;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import org.mule.api.MuleMessage;
 import org.mule.api.client.MuleClient;
-import org.mule.modules.cors.CORSModule;
+import org.mule.modules.cors.Constants;
 import org.mule.modules.cors.adapters.CORSModuleInjectionAdapter;
 import org.mule.tck.junit4.FunctionalTestCase;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import java.util.HashMap;
+
 import org.junit.Before;
-import org.mule.api.MuleMessage;
-import org.mule.modules.cors.Constants;
+import org.junit.Test;
 
 public class CORSModuleTest extends FunctionalTestCase
 {
@@ -57,6 +64,11 @@ public class CORSModuleTest extends FunctionalTestCase
      */
     public static final String CORS_PUBLIC_ENDPOINT_URL = "http://localhost:9081/public";
     
+    /**
+     * An endpoint to test response headers
+     */
+    public static final String CORS_HEADERS_ENDPOINT_URL = "http://localhost:9081/headers";
+
     /**
      * The origin we have configured on the test case
      */
@@ -254,4 +266,22 @@ public class CORSModuleTest extends FunctionalTestCase
 
         module.start();
     }
+
+    @Test
+    public void testResponseHeaders() throws Exception {
+
+        headers.put("http.method", "POST");
+
+        MuleMessage response = client.send(CORS_HEADERS_ENDPOINT_URL, "", headers);
+
+        assertNotNull("Response should not be null", response);
+
+        String muleMessageId = response.getInboundProperty("MULE_ROOT_MESSAGE_ID");
+        assertNull("header MULE_ROOT_MESSAGE_ID should not be present", muleMessageId);
+
+        //the payload should be the expected
+        assertThat(response.getPayloadAsString(), equalTo(EXPECTED_RETURN));
+
+    }
+
 }

--- a/src/test/resources/mule-config.xml
+++ b/src/test/resources/mule-config.xml
@@ -67,4 +67,12 @@
         <!-- read the expected return from the test case for convenience -->
         <set-payload value="#{T(com.mulesoft.modules.cors.CORSModuleTest).EXPECTED_RETURN}" />
     </flow>
+
+    <flow name="headersFlow">
+        <http:inbound-endpoint address="#{T(com.mulesoft.modules.cors.CORSModuleTest).CORS_HEADERS_ENDPOINT_URL}" />
+        <cors:validate publicResource="true" config-ref="defaultConfig" />
+        <copy-properties propertyName="*"/>
+        <http:outbound-endpoint address="#{T(com.mulesoft.modules.cors.CORSModuleTest).CORS_PUBLIC_ENDPOINT_URL}" />
+    </flow>
+
 </mule>


### PR DESCRIPTION
the response event should be exactly the one returned by the callback
and should not contain any property of the request message
not present in the response message.
